### PR TITLE
fix typo - change "You Loose" to "You Lose"

### DIFF
--- a/lib/pong.js
+++ b/lib/pong.js
@@ -153,7 +153,7 @@ module.exports = function pong () {
           const y = terminal.height / 2 - 2.5;
           terminal.removeAllListeners();
           terminal.clear();
-          terminal.writeLarge(playerScored ? "You Win!" : "You Loose", x, y);
+          terminal.writeLarge(playerScored ? "You Win!" : "You Lose", x, y);
           terminal.write("Press R to restart, Q to quit", terminal.width / 2 - 15.5, terminal.height / 2 + 3.5);
           terminal.once("r", init);
           terminal.on("q", () => process.exit());

--- a/lib/pong.js
+++ b/lib/pong.js
@@ -149,7 +149,7 @@ module.exports = function pong () {
         if (playerScored) score = ++playerScore;
         else if (cpuScored) score = ++cpuScore;
         if (score === 10) {
-          let x = playerScored ? terminal.width / 2 - 29 : terminal.width / 2 - 33;
+          let x = playerScored ? terminal.width / 2 - 29 : terminal.width / 2 - 29;
           const y = terminal.height / 2 - 2.5;
           terminal.removeAllListeners();
           terminal.clear();
@@ -173,6 +173,7 @@ module.exports = function pong () {
     reset();
     onresize();
   }
+
 
   function drawTitleScreen () {
     terminal.writeLarge("PONG", terminal.width / 2 - 15, terminal.height / 3 - 2.5);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "command-line-pong",
-  "version": "1.3.1",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "command-line-draw": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/command-line-draw/-/command-line-draw-1.0.6.tgz",
-      "integrity": "sha512-wEao69B19YU3Gnr/3VnS0Pv+WFPhwaPEDmOaMAlze13FTbTs+uYkwdpniIvgF8Hww04B7PqUEIZRnxLZbZ0Gaw=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/command-line-draw/-/command-line-draw-1.2.2.tgz",
+      "integrity": "sha512-jJ/yDon82XfhUU/Cg2qdO2AHzLT1nq524iaCh5ux5OTDj0pn82jzcFflZCR7U0wHJruoDpqd5cQUbfCqq0hXEA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "command-line-pong",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "This is pong in the command line",
   "main": "./lib/pong.js",
   "scripts": {


### PR DESCRIPTION
There was a typo where it says "you loose" instead of "you lose" so I fixed it.